### PR TITLE
Stop using Qt keywords in libraries

### DIFF
--- a/include/abstract_widget_list.hpp
+++ b/include/abstract_widget_list.hpp
@@ -51,7 +51,7 @@ public:
     void setRowHeight(int row, int height);
 
 
-public slots:
+public Q_SLOTS:
     /**
      *  \brief Remove row i
      */
@@ -62,7 +62,7 @@ public slots:
      */
     virtual void append() = 0;
 
-signals:
+Q_SIGNALS:
     void removed(int i);
 
 protected:
@@ -93,7 +93,7 @@ protected:
      */
     void clear();
 
-private slots:
+private Q_SLOTS:
     void remove_clicked(QWidget* w);
     void up_clicked(QWidget* w);
     void down_clicked(QWidget* w);

--- a/include/bound_color_selector.hpp
+++ b/include/bound_color_selector.hpp
@@ -37,7 +37,7 @@ private:
 public:
     explicit BoundColorSelector(QColor* reference, QWidget *parent = 0);
 
-private slots:
+private Q_SLOTS:
     void update_reference(QColor);
 };
 } // namespace color_widgets

--- a/include/color_2d_slider.hpp
+++ b/include/color_2d_slider.hpp
@@ -74,7 +74,7 @@ public:
     Component componentX() const;
     Component componentY() const;
 
-public slots:
+public Q_SLOTS:
 
     /// Set current color
     void setColor(const QColor& c);
@@ -97,7 +97,7 @@ public slots:
     void setComponentX(Component componentX);
     void setComponentY(Component componentY);
 
-signals:
+Q_SIGNALS:
     /**
      * Emitted when the user selects a color or setColor is called
      */

--- a/include/color_dialog.hpp
+++ b/include/color_dialog.hpp
@@ -86,7 +86,7 @@ public:
 
     ColorWheel::DisplayFlags wheelFlags() const;
 
-public slots:
+public Q_SLOTS:
 
     /**
      * Change color
@@ -106,7 +106,7 @@ public slots:
      */
     void setAlphaEnabled(bool a);
 
-signals:
+Q_SIGNALS:
     /**
      * The current color was changed
      */
@@ -120,7 +120,7 @@ signals:
     void wheelFlagsChanged(ColorWheel::DisplayFlags flags);
     void alphaEnabledChanged(bool alphaEnabled);
 
-private slots:
+private Q_SLOTS:
     /// Update all the Ui elements to match the selected color
     void update_widgets();
     /// Update from HSV sliders

--- a/include/color_line_edit.hpp
+++ b/include/color_line_edit.hpp
@@ -62,12 +62,12 @@ public:
     bool showAlpha() const;
     bool previewColor() const;
 
-public slots:
+public Q_SLOTS:
     void setColor(const QColor& color);
     void setShowAlpha(bool showAlpha);
     void setPreviewColor(bool previewColor);
 
-signals:
+Q_SIGNALS:
     /**
      * \brief Emitted when the color is changed by any means
      */

--- a/include/color_list_widget.hpp
+++ b/include/color_list_widget.hpp
@@ -47,14 +47,14 @@ public:
 
     ColorWheel::DisplayFlags wheelFlags() const;
 
-signals:
+Q_SIGNALS:
     void colorsChanged(const QList<QColor>&);
     void wheelFlagsChanged(ColorWheel::DisplayFlags flags);
 
-public slots:
+public Q_SLOTS:
     void setWheelFlags(ColorWheel::DisplayFlags flags);
 
-private slots:
+private Q_SLOTS:
     void emit_changed();
     void handle_removed(int);
     void color_changed(int row);

--- a/include/color_palette.hpp
+++ b/include/color_palette.hpp
@@ -137,7 +137,7 @@ public:
      */
     QPixmap preview(const QSize& size, const QColor& background=Qt::transparent) const;
 
-public slots:
+public Q_SLOTS:
     void setColumns(int columns);
 
     void setColors(const QVector<QColor>& colors);
@@ -183,7 +183,7 @@ public slots:
     void setFileName(const QString& name);
     void setDirty(bool dirty);
 
-signals:
+Q_SIGNALS:
     /**
      * \brief Emitted when all the colors have changed
      */

--- a/include/color_palette_model.hpp
+++ b/include/color_palette_model.hpp
@@ -114,7 +114,7 @@ public:
      */
     int indexFromFile(const QString& filename) const;
 
-public slots:
+public Q_SLOTS:
     void setSavePath(const QString& savePath);
     void setSearchPaths(const QStringList& searchPaths);
     void addSearchPath(const QString& path);
@@ -125,7 +125,7 @@ public slots:
      */
     void load();
 
-signals:
+Q_SIGNALS:
     void savePathChanged(const QString& savePath);
     void searchPathsChanged(const QStringList& searchPaths);
     void iconSizeChanged(const QSize& iconSize);

--- a/include/color_palette_widget.hpp
+++ b/include/color_palette_widget.hpp
@@ -118,7 +118,7 @@ public:
 
     int currentRow() const;
 
-public slots:
+public Q_SLOTS:
     void setModel(ColorPaletteModel* model);
     void setColorSize(const QSize& colorSize);
     void setColorSizePolicy(Swatch::ColorSizePolicy colorSizePolicy);
@@ -156,7 +156,7 @@ public slots:
      */
     void setCurrentRow(int currentRow);
 
-signals:
+Q_SIGNALS:
     void modelChanged(ColorPaletteModel* model);
     void colorSizeChanged(const QSize& colorSize);
     void colorSizePolicyChanged(Swatch::ColorSizePolicy colorSizePolicy);
@@ -168,7 +168,7 @@ signals:
     void borderChanged(const QPen& border);
     void currentRowChanged(int currentRow);
 
-private slots:
+private Q_SLOTS:
     void on_palette_list_currentIndexChanged(int index);
     void on_swatch_doubleClicked(int index);
 

--- a/include/color_preview.hpp
+++ b/include/color_preview.hpp
@@ -48,6 +48,7 @@ public:
         SplitAlpha, ///< Show both solid and transparent side by side
         SplitColor  ///< Show current and comparison colors side by side
     };
+    Q_ENUMS(DisplayMode)
 
     explicit ColorPreview(QWidget *parent = 0);
     ~ColorPreview();
@@ -74,14 +75,14 @@ public:
 
     void paint(QPainter &painter, QRect rect) const;
     
-public slots:
+public Q_SLOTS:
     /// Set current color
     void setColor(const QColor &c);
 
     /// Set the comparison color
     void setComparisonColor(const QColor &c);
 
-signals:
+Q_SIGNALS:
     /// Emitted when the user clicks on the widget
     void clicked();
 
@@ -100,5 +101,6 @@ private:
 };
 
 } // namespace color_widgets
+Q_DECLARE_METATYPE(color_widgets::ColorPreview::DisplayMode)
 
 #endif // COLOR_PREVIEW_HPP

--- a/include/color_selector.hpp
+++ b/include/color_selector.hpp
@@ -55,14 +55,14 @@ public:
 
     ColorWheel::DisplayFlags wheelFlags() const;
 
-signals:
+Q_SIGNALS:
     void wheelFlagsChanged(ColorWheel::DisplayFlags flags);
 
-public slots:
+public Q_SLOTS:
     void showDialog();
     void setWheelFlags(ColorWheel::DisplayFlags flags);
 
-private slots:
+private Q_SLOTS:
     void accept_dialog();
     void reject_dialog();
     void update_old_color(const QColor &c);

--- a/include/color_wheel.hpp
+++ b/include/color_wheel.hpp
@@ -109,7 +109,7 @@ public:
      */
     void setDisplayFlag(DisplayFlags flag, DisplayFlags mask);
 
-public slots:
+public Q_SLOTS:
 
     /// Set current color
     void setColor(QColor c);
@@ -135,7 +135,7 @@ public slots:
      */
     void setDisplayFlags(ColorWheel::DisplayFlags flags);
 
-signals:
+Q_SIGNALS:
     /**
      * Emitted when the user selects a color or setColor is called
      */

--- a/include/hue_slider.hpp
+++ b/include/hue_slider.hpp
@@ -68,7 +68,7 @@ public:
     QColor color() const;
     qreal colorHue() const;
 
-public slots:
+public Q_SLOTS:
     void setColorValue(qreal value);
     void setColorSaturation(qreal value);
     void setColorAlpha(qreal alpha);
@@ -82,7 +82,7 @@ public slots:
      */
     void setFullColor(const QColor& color);
 
-signals:
+Q_SIGNALS:
     void colorHueChanged(qreal colorHue);
 
 private:

--- a/include/swatch.hpp
+++ b/include/swatch.hpp
@@ -132,7 +132,7 @@ public:
 
     bool readOnly() const;
 
-public slots:
+public Q_SLOTS:
     void setPalette(const ColorPalette& palette);
     void setSelected(int selected);
     void clearSelection();
@@ -147,7 +147,7 @@ public slots:
      **/
     void removeSelected();
 
-signals:
+Q_SIGNALS:
     void paletteChanged(const ColorPalette& palette);
     void selectedChanged(int selected);
     void colorSelected(const QColor& color);
@@ -178,7 +178,7 @@ protected:
     void dragLeaveEvent(QDragLeaveEvent *event) Q_DECL_OVERRIDE;
     void dropEvent(QDropEvent* event) Q_DECL_OVERRIDE;
 
-protected slots:
+protected Q_SLOTS:
     /**
      * \brief Connected to the internal palette object to keep eveything consistent
      */

--- a/src/abstract_widget_list.cpp
+++ b/src/abstract_widget_list.cpp
@@ -105,7 +105,7 @@ void AbstractWidgetList::remove(int i)
         else if ( i != 0 && i == count() )
             p->table->cellWidget(count()-1,2)->setEnabled(false);
 
-        emit removed(i);
+        Q_EMIT removed(i);
     }
 }
 

--- a/src/color_2d_slider.cpp
+++ b/src/color_2d_slider.cpp
@@ -176,7 +176,7 @@ void Color2DSlider::setColor(const QColor& c)
     p->val = c.valueF();
     p->renderSquare(size());
     update();
-    emit colorChanged(color());
+    Q_EMIT colorChanged(color());
 }
 
 void Color2DSlider::setHue(qreal h)
@@ -184,7 +184,7 @@ void Color2DSlider::setHue(qreal h)
     p->hue = h;
     p->renderSquare(size());
     update();
-    emit colorChanged(color());
+    Q_EMIT colorChanged(color());
 }
 
 void Color2DSlider::setSaturation(qreal s)
@@ -192,7 +192,7 @@ void Color2DSlider::setSaturation(qreal s)
     p->sat = s;
     p->renderSquare(size());
     update();
-    emit colorChanged(color());
+    Q_EMIT colorChanged(color());
 }
 
 void Color2DSlider::setValue(qreal v)
@@ -200,7 +200,7 @@ void Color2DSlider::setValue(qreal v)
     p->val = v;
     p->renderSquare(size());
     update();
-    emit colorChanged(color());
+    Q_EMIT colorChanged(color());
 }
 
 void Color2DSlider::setComponentX(Color2DSlider::Component componentX)
@@ -210,7 +210,7 @@ void Color2DSlider::setComponentX(Color2DSlider::Component componentX)
         p->comp_x = componentX;
         p->renderSquare(size());
         update();
-        emit componentXChanged(p->comp_x);
+        Q_EMIT componentXChanged(p->comp_x);
     }
 }
 
@@ -221,7 +221,7 @@ void Color2DSlider::setComponentY(Color2DSlider::Component componentY)
         p->comp_y = componentY;
         p->renderSquare(size());
         update();
-        emit componentXChanged(p->comp_y);
+        Q_EMIT componentXChanged(p->comp_y);
     }
 }
 
@@ -239,21 +239,21 @@ void Color2DSlider::paintEvent(QPaintEvent*)
 void Color2DSlider::mousePressEvent(QMouseEvent* event)
 {
     p->setColorFromPos(event->pos(), size());
-    emit colorChanged(color());
+    Q_EMIT colorChanged(color());
     update();
 }
 
 void Color2DSlider::mouseMoveEvent(QMouseEvent* event)
 {
     p->setColorFromPos(event->pos(), size());
-    emit colorChanged(color());
+    Q_EMIT colorChanged(color());
     update();
 }
 
 void Color2DSlider::mouseReleaseEvent(QMouseEvent* event)
 {
     p->setColorFromPos(event->pos(), size());
-    emit colorChanged(color());
+    Q_EMIT colorChanged(color());
     update();
 }
 

--- a/src/color_delegate.cpp
+++ b/src/color_delegate.cpp
@@ -86,6 +86,8 @@ bool ColorDelegate::editorEvent(QEvent* event,
 
 QSize ColorDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
+    Q_UNUSED(index)
+    Q_UNUSED(option)
     return QSize(24,16);
 }
 

--- a/src/color_dialog.cpp
+++ b/src/color_dialog.cpp
@@ -131,7 +131,7 @@ void ColorDialog::setAlphaEnabled(bool a)
         p->ui.slide_alpha->setVisible(a);
         p->ui.spin_alpha->setVisible(a);
 
-        emit alphaEnabledChanged(a);
+        Q_EMIT alphaEnabledChanged(a);
     }
 }
 
@@ -161,7 +161,7 @@ void ColorDialog::update_widgets()
 {
     bool blocked = signalsBlocked();
     blockSignals(true);
-    foreach(QWidget* w, findChildren<QWidget*>())
+    Q_FOREACH(QWidget* w, findChildren<QWidget*>())
         w->blockSignals(true);
 
     QColor col = color();
@@ -210,10 +210,10 @@ void ColorDialog::update_widgets()
     p->ui.preview->setColor(col);
 
     blockSignals(blocked);
-    foreach(QWidget* w, findChildren<QWidget*>())
+    Q_FOREACH(QWidget* w, findChildren<QWidget*>())
         w->blockSignals(false);
 
-    emit colorChanged(col);
+    Q_EMIT colorChanged(col);
 }
 
 void ColorDialog::set_hsv()
@@ -265,7 +265,7 @@ void ColorDialog::on_buttonBox_clicked(QAbstractButton *btn)
     case QDialogButtonBox::ApplyRole:
         // Explicitly select the color
         p->ui.preview->setComparisonColor(color());
-        emit colorSelected(color());
+        Q_EMIT colorSelected(color());
         break;
 
     case QDialogButtonBox::ActionRole:

--- a/src/color_line_edit.cpp
+++ b/src/color_line_edit.cpp
@@ -73,7 +73,7 @@ ColorLineEdit::ColorLineEdit(QWidget* parent)
     /*connect(this, &QLineEdit::textChanged, [this](const QString& text){
         QColor color = p->colorFromString(text);
         if ( color.isValid() )
-            emit colorChanged(color);
+            Q_EMIT colorChanged(color);
     });*/
     connect(this, &QLineEdit::textEdited, [this](const QString& text){
         QColor color = color_widgets::colorFromString(text, p->show_alpha);
@@ -81,8 +81,8 @@ ColorLineEdit::ColorLineEdit(QWidget* parent)
         {
             p->color = color;
             p->setPalette(color, this);
-            emit colorEdited(color);
-            emit colorChanged(color);
+            Q_EMIT colorEdited(color);
+            Q_EMIT colorChanged(color);
         }
     });
     connect(this, &QLineEdit::editingFinished, [this](){
@@ -90,14 +90,14 @@ ColorLineEdit::ColorLineEdit(QWidget* parent)
         if ( color.isValid() )
         {
             p->color = color;
-            emit colorEditingFinished(color);
-            emit colorChanged(color);
+            Q_EMIT colorEditingFinished(color);
+            Q_EMIT colorChanged(color);
         }
         else
         {
             setText(color_widgets::stringFromColor(p->color, p->show_alpha));
-            emit colorEditingFinished(p->color);
-            emit colorChanged(color);
+            Q_EMIT colorEditingFinished(p->color);
+            Q_EMIT colorChanged(color);
         }
         p->setPalette(p->color, this);
     });
@@ -120,7 +120,7 @@ void ColorLineEdit::setColor(const QColor& color)
         p->color = color;
         p->setPalette(p->color, this);
         setText(color_widgets::stringFromColor(p->color, p->show_alpha));
-        emit colorChanged(p->color);
+        Q_EMIT colorChanged(p->color);
     }
 }
 
@@ -131,7 +131,7 @@ void ColorLineEdit::setShowAlpha(bool showAlpha)
         p->show_alpha = showAlpha;
         p->setPalette(p->color, this);
         setText(color_widgets::stringFromColor(p->color, p->show_alpha));
-        emit showAlphaChanged(p->show_alpha);
+        Q_EMIT showAlphaChanged(p->show_alpha);
     }
 }
 
@@ -191,7 +191,7 @@ void ColorLineEdit::setPreviewColor(bool previewColor)
         else
             setPalette(QApplication::palette());
 
-        emit previewColorChanged(p->preview_color);
+        Q_EMIT previewColorChanged(p->preview_color);
     }
 }
 

--- a/src/color_list_widget.cpp
+++ b/src/color_list_widget.cpp
@@ -56,7 +56,7 @@ void ColorListWidget::setColors(const QList<QColor> &colors)
     p->colors = colors;
     for(int i = 0;i < colors.size();i++ )
         append_widget(i);
-    emit colorsChanged(colors);
+    Q_EMIT colorsChanged(colors);
 }
 
 void ColorListWidget::swap(int a, int b)
@@ -68,7 +68,7 @@ void ColorListWidget::swap(int a, int b)
         QColor ca = sa->color();
         sa->setColor(sb->color());
         sb->setColor(ca);
-        emit colorsChanged(p->colors);
+        Q_EMIT colorsChanged(p->colors);
     }
 }
 
@@ -76,18 +76,18 @@ void ColorListWidget::append()
 {
     p->colors.push_back(Qt::black);
     append_widget(p->colors.size()-1);
-    emit colorsChanged(p->colors);
+    Q_EMIT colorsChanged(p->colors);
 }
 
 void ColorListWidget::emit_changed()
 {
-    emit colorsChanged(p->colors);
+    Q_EMIT colorsChanged(p->colors);
 }
 
 void ColorListWidget::handle_removed(int i)
 {
     p->colors.removeAt(i);
-    emit colorsChanged(p->colors);
+    Q_EMIT colorsChanged(p->colors);
 }
 
 void ColorListWidget::color_changed(int row)
@@ -96,7 +96,7 @@ void ColorListWidget::color_changed(int row)
     if ( cs )
     {
         p->colors[row] = cs->color();
-        emit colorsChanged(p->colors);
+        Q_EMIT colorsChanged(p->colors);
     }
 }
 
@@ -124,7 +124,7 @@ void ColorListWidget::setWheelFlags(ColorWheel::DisplayFlags flags)
     if ( p->wheel_flags != flags )
     {
         p->wheel_flags = flags;
-        emit wheelFlagsChanged(flags);
+        Q_EMIT wheelFlagsChanged(flags);
     }
 }
 

--- a/src/color_palette.cpp
+++ b/src/color_palette.cpp
@@ -103,11 +103,11 @@ ColorPalette& ColorPalette::operator=(ColorPalette&& other)
 
 void ColorPalette::emitUpdate()
 {
-    emit colorsChanged(p->colors);
-    emit columnsChanged(p->columns);
-    emit nameChanged(p->name);
-    emit fileNameChanged(p->fileName);
-    emit dirtyChanged(p->dirty);
+    Q_EMIT colorsChanged(p->colors);
+    Q_EMIT columnsChanged(p->columns);
+    Q_EMIT nameChanged(p->name);
+    Q_EMIT fileNameChanged(p->fileName);
+    Q_EMIT dirtyChanged(p->dirty);
 }
 
 QColor ColorPalette::colorAt(int index) const
@@ -150,7 +150,7 @@ void ColorPalette::loadColorTable(const QVector<QRgb>& color_table)
         color.setAlpha(255);
         p->colors.push_back(qMakePair(color,QString()));
     }
-    emit colorsChanged(p->colors);
+    Q_EMIT colorsChanged(p->colors);
     setDirty(true);
 }
 
@@ -171,7 +171,7 @@ bool ColorPalette::loadImage(const QImage& image)
             p->colors.push_back(qMakePair(color,QString()));
         }
     }
-    emit colorsChanged(p->colors);
+    Q_EMIT colorsChanged(p->colors);
     setDirty(true);
     return true;
 }
@@ -249,7 +249,7 @@ bool ColorPalette::load(const QString& name)
         p->colors.push_back(qMakePair(QColor(r, g, b), line));
     }
 
-    emit colorsChanged(p->colors);
+    Q_EMIT colorsChanged(p->colors);
     setDirty(false);
 
     return true;
@@ -321,24 +321,24 @@ void ColorPalette::setColumns(int columns)
     if ( columns != p->columns )
     {
         setDirty(true);
-        emit columnsChanged( p->columns = columns );
+        Q_EMIT columnsChanged( p->columns = columns );
     }
 }
 
 void ColorPalette::setColors(const QVector<QColor>& colors)
 {
     p->colors.clear();
-    foreach(const QColor& col, colors)
+    Q_FOREACH(const QColor& col, colors)
         p->colors.push_back(qMakePair(col,QString()));
     setDirty(true);
-    emit colorsChanged(p->colors);
+    Q_EMIT colorsChanged(p->colors);
 }
 
 void ColorPalette::setColors(const QVector<QPair<QColor,QString> >& colors)
 {
     p->colors = colors;
     setDirty(true);
-    emit colorsChanged(p->colors);
+    Q_EMIT colorsChanged(p->colors);
 }
 
 
@@ -350,8 +350,8 @@ void ColorPalette::setColorAt(int index, const QColor& color)
     p->colors[index].first = color;
 
     setDirty(true);
-    emit colorChanged(index);
-    emit colorsUpdated(p->colors);
+    Q_EMIT colorChanged(index);
+    Q_EMIT colorsUpdated(p->colors);
 }
 
 void ColorPalette::setColorAt(int index, const QColor& color, const QString& name)
@@ -362,8 +362,8 @@ void ColorPalette::setColorAt(int index, const QColor& color, const QString& nam
     p->colors[index].first = color;
     p->colors[index].second = name;
     setDirty(true);
-    emit colorChanged(index);
-    emit colorsUpdated(p->colors);
+    Q_EMIT colorChanged(index);
+    Q_EMIT colorsUpdated(p->colors);
 }
 
 void ColorPalette::setNameAt(int index, const QString& name)
@@ -374,8 +374,8 @@ void ColorPalette::setNameAt(int index, const QString& name)
     p->colors[index].second = name;
 
     setDirty(true);
-    emit colorChanged(index);
-    emit colorsUpdated(p->colors);
+    Q_EMIT colorChanged(index);
+    Q_EMIT colorsUpdated(p->colors);
 }
 
 
@@ -383,8 +383,8 @@ void ColorPalette::appendColor(const QColor& color, const QString& name)
 {
     p->colors.push_back(qMakePair(color,name));
     setDirty(true);
-    emit colorAdded(p->colors.size()-1);
-    emit colorsUpdated(p->colors);
+    Q_EMIT colorAdded(p->colors.size()-1);
+    Q_EMIT colorsUpdated(p->colors);
 }
 
 void ColorPalette::insertColor(int index, const QColor& color, const QString& name)
@@ -395,8 +395,8 @@ void ColorPalette::insertColor(int index, const QColor& color, const QString& na
     p->colors.insert(index, qMakePair(color, name));
 
     setDirty(true);
-    emit colorAdded(index);
-    emit colorsUpdated(p->colors);
+    Q_EMIT colorAdded(index);
+    Q_EMIT colorsUpdated(p->colors);
 }
 
 void ColorPalette::eraseColor(int index)
@@ -407,8 +407,8 @@ void ColorPalette::eraseColor(int index)
     p->colors.remove(index);
 
     setDirty(true);
-    emit colorRemoved(index);
-    emit colorsUpdated(p->colors);
+    Q_EMIT colorRemoved(index);
+    Q_EMIT colorsUpdated(p->colors);
 }
 
 void ColorPalette::setName(const QString& name)
@@ -467,7 +467,7 @@ bool ColorPalette::dirty() const
 void ColorPalette::setDirty(bool dirty)
 {
     if ( dirty != p->dirty )
-        emit dirtyChanged( p->dirty = dirty );
+        Q_EMIT dirtyChanged( p->dirty = dirty );
 }
 
 QVector<QColor> ColorPalette::onlyColors() const

--- a/src/color_palette_model.cpp
+++ b/src/color_palette_model.cpp
@@ -149,6 +149,8 @@ QVariant ColorPaletteModel::data(const QModelIndex &index, int role) const
 
 bool ColorPaletteModel::removeRows(int row, int count, const QModelIndex & parent)
 {
+    Q_UNUSED(parent)
+
     if ( !p->acceptable(row) || count <= 0 )
         return false;
 
@@ -177,7 +179,7 @@ QSize ColorPaletteModel::iconSize() const
 void ColorPaletteModel::setIconSize(const QSize& iconSize)
 {
     if ( p->icon_size != iconSize )
-        emit iconSizeChanged( p->icon_size = iconSize );
+        Q_EMIT iconSizeChanged( p->icon_size = iconSize );
 }
 
 QString ColorPaletteModel::savePath() const
@@ -193,13 +195,13 @@ QStringList ColorPaletteModel::searchPaths() const
 void ColorPaletteModel::setSavePath(const QString& savePath)
 {
     if ( p->save_path != savePath )
-        emit savePathChanged( p->save_path = savePath );
+        Q_EMIT savePathChanged( p->save_path = savePath );
 }
 
 void ColorPaletteModel::setSearchPaths(const QStringList& searchPaths)
 {
     if ( p->search_paths != searchPaths )
-        emit searchPathsChanged( p->search_paths = searchPaths );
+        Q_EMIT searchPathsChanged( p->search_paths = searchPaths );
 }
 
 void ColorPaletteModel::addSearchPath(const QString& path)
@@ -209,7 +211,7 @@ void ColorPaletteModel::addSearchPath(const QString& path)
     if ( !p->search_paths.contains(path) )
     {
         p->search_paths.push_back(path);
-        emit searchPathsChanged( p->search_paths );
+        Q_EMIT searchPathsChanged( p->search_paths );
     }
 }
 

--- a/src/color_palette_widget.cpp
+++ b/src/color_palette_widget.cpp
@@ -200,7 +200,7 @@ ColorPaletteWidget::ColorPaletteWidget(QWidget* parent)
     });
 
     QString image_formats;
-    foreach(QByteArray ba, QImageReader::supportedImageFormats())
+    Q_FOREACH(QByteArray ba, QImageReader::supportedImageFormats())
         image_formats += " *."+QString(ba);
 
     connect(p->button_palette_open, &QAbstractButton::clicked, [this, image_formats](){
@@ -326,7 +326,7 @@ void ColorPaletteWidget::setReadOnly(bool readOnly)
     p->swatch->setReadOnly(readOnly);
     p->group_edit_list->setVisible(!readOnly);
     p->group_edit_palette->setVisible(!readOnly);
-    emit readOnlyChanged(p->read_only = readOnly);
+    Q_EMIT readOnlyChanged(p->read_only = readOnly);
 }
 
 bool ColorPaletteWidget::setCurrentColor(const QColor& color)

--- a/src/color_preview.cpp
+++ b/src/color_preview.cpp
@@ -94,17 +94,17 @@ void ColorPreview::paint(QPainter &painter, QRect rect) const
 {
     QColor c1, c2;
     switch(p->display_mode) {
-    case NoAlpha:
+    case DisplayMode::NoAlpha:
         c1 = c2 = p->col.rgb();
         break;
-    case AllAlpha:
+    case DisplayMode::AllAlpha:
         c1 = c2 = p->col;
         break;
-    case SplitAlpha:
+    case DisplayMode::SplitAlpha:
         c1 = p->col.rgb();
         c2 = p->col;
         break;
-    case SplitColor:
+    case DisplayMode::SplitColor:
         c1 = p->comparison;
         c2 = p->col;
         break;
@@ -132,7 +132,7 @@ void ColorPreview::setColor(const QColor &c)
 {
     p->col = c;
     update();
-    emit colorChanged(c);
+    Q_EMIT colorChanged(c);
 }
 
 void ColorPreview::setComparisonColor(const QColor &c)
@@ -156,7 +156,7 @@ void ColorPreview::resizeEvent(QResizeEvent *)
 void ColorPreview::mouseReleaseEvent(QMouseEvent * ev)
 {
     if ( QRect(QPoint(0,0),size()).contains(ev->pos()) )
-        emit clicked();
+        Q_EMIT clicked();
 }
 
 void ColorPreview::mouseMoveEvent(QMouseEvent *ev)

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -364,8 +364,8 @@ void ColorWheel::mouseMoveEvent(QMouseEvent *ev)
         p->hue = p->line_to_point(ev->pos()).angle()/360.0;
         p->render_inner_selector();
 
-        emit colorSelected(color());
-        emit colorChanged(color());
+        Q_EMIT colorSelected(color());
+        Q_EMIT colorChanged(color());
         update();
     }
     else if(p->mouse_status == DragSquare)
@@ -397,8 +397,8 @@ void ColorWheel::mouseMoveEvent(QMouseEvent *ev)
                 p->sat = qBound(0.0, (pt.y()-ymin)/slice_h, 1.0);
         }
 
-        emit colorSelected(color());
-        emit colorChanged(color());
+        Q_EMIT colorSelected(color());
+        Q_EMIT colorChanged(color());
         update();
     }
 }
@@ -438,7 +438,7 @@ void ColorWheel::setColor(QColor c)
     if (!qFuzzyCompare(oldh+1, p->hue+1))
         p->render_inner_selector();
     update();
-    emit colorChanged(c);
+    Q_EMIT colorChanged(c);
 }
 
 void ColorWheel::setHue(qreal h)
@@ -503,7 +503,7 @@ void ColorWheel::setDisplayFlags(DisplayFlags flags)
     p->display_flags = flags;
     p->render_inner_selector();
     update();
-    emit displayFlagsChanged(flags);
+    Q_EMIT displayFlagsChanged(flags);
 }
 
 ColorWheel::DisplayFlags ColorWheel::displayFlags(DisplayFlags mask) const

--- a/src/hue_slider.cpp
+++ b/src/hue_slider.cpp
@@ -39,7 +39,7 @@ public:
     {
         w->setRange(0, 359);
         connect(w, &QSlider::valueChanged, [this]{
-            emit w->colorHueChanged(percent());
+            Q_EMIT w->colorHueChanged(percent());
         });
         updateGradient();
     }

--- a/src/swatch.cpp
+++ b/src/swatch.cpp
@@ -215,7 +215,7 @@ Swatch::Swatch(QWidget* parent)
     connect(&p->palette, &ColorPalette::colorsUpdated, this, (void(QWidget::*)())&QWidget::update);
     connect(&p->palette, &ColorPalette::colorChanged, [this](int index){
         if ( index == p->selected )
-            emit colorSelected( p->palette.colorAt(index) );
+            Q_EMIT colorSelected( p->palette.colorAt(index) );
     });
     connect(&p->palette, &ColorPalette::colorRemoved, [this](int index){
         if ( index == p->selected )
@@ -301,7 +301,7 @@ void Swatch::setPalette(const ColorPalette& palette)
     clearSelection();
     p->palette = palette;
     update();
-    emit paletteChanged(p->palette);
+    Q_EMIT paletteChanged(p->palette);
 }
 
 void Swatch::setSelected(int selected)
@@ -311,9 +311,9 @@ void Swatch::setSelected(int selected)
 
     if ( selected != p->selected )
     {
-        emit selectedChanged( p->selected = selected );
+        Q_EMIT selectedChanged( p->selected = selected );
         if ( selected != -1 )
-            emit colorSelected( p->palette.colorAt(p->selected) );
+            Q_EMIT colorSelected( p->palette.colorAt(p->selected) );
         update();
     }
 }
@@ -325,6 +325,7 @@ void Swatch::clearSelection()
 
 void Swatch::paintEvent(QPaintEvent* event)
 {
+    Q_UNUSED(event)
     QSize rowcols = p->rowcols();
     if ( rowcols.isEmpty() )
         return;
@@ -513,7 +514,7 @@ void Swatch::mousePressEvent(QMouseEvent *event)
     {
         int index = indexAt(event->pos());
         if ( index != -1 )
-            emit rightClicked(index);
+            Q_EMIT rightClicked(index);
     }
 }
 
@@ -555,7 +556,7 @@ void Swatch::mouseDoubleClickEvent(QMouseEvent *event)
     {
         int index = indexAt(event->pos());
         if ( index != -1 )
-            emit doubleClicked(index);
+            Q_EMIT doubleClicked(index);
     }
 }
 
@@ -597,6 +598,7 @@ void Swatch::dragMoveEvent(QDragMoveEvent* event)
 
 void Swatch::dragLeaveEvent(QDragLeaveEvent *event)
 {
+    Q_UNUSED(event)
     p->clearDrop();
 }
 
@@ -670,7 +672,7 @@ QSize Swatch::colorSize() const
 void Swatch::setColorSize(const QSize& colorSize)
 {
     if ( p->color_size != colorSize )
-        emit colorSizeChanged(p->color_size = colorSize);
+        Q_EMIT colorSizeChanged(p->color_size = colorSize);
 }
 
 Swatch::ColorSizePolicy Swatch::colorSizePolicy() const
@@ -685,7 +687,7 @@ void Swatch::setColorSizePolicy(ColorSizePolicy colorSizePolicy)
         setMinimumSize(0,0);
         setFixedSize(QWIDGETSIZE_MAX,QWIDGETSIZE_MAX);
         paletteModified();
-        emit colorSizePolicyChanged(p->size_policy = colorSizePolicy);
+        Q_EMIT colorSizePolicyChanged(p->size_policy = colorSizePolicy);
     }
 }
 
@@ -706,8 +708,8 @@ void Swatch::setForcedColumns(int forcedColumns)
 
     if ( forcedColumns != p->forced_columns )
     {
-        emit forcedColumnsChanged(p->forced_columns = forcedColumns);
-        emit forcedRowsChanged(p->forced_rows = 0);
+        Q_EMIT forcedColumnsChanged(p->forced_columns = forcedColumns);
+        Q_EMIT forcedRowsChanged(p->forced_rows = 0);
     }
 }
 
@@ -718,8 +720,8 @@ void Swatch::setForcedRows(int forcedRows)
 
     if ( forcedRows != p->forced_rows )
     {
-        emit forcedColumnsChanged(p->forced_columns = 0);
-        emit forcedRowsChanged(p->forced_rows = forcedRows);
+        Q_EMIT forcedColumnsChanged(p->forced_columns = 0);
+        Q_EMIT forcedRowsChanged(p->forced_rows = forcedRows);
     }
 }
 
@@ -732,7 +734,7 @@ void Swatch::setReadOnly(bool readOnly)
 {
     if ( readOnly != p->readonly )
     {
-        emit readOnlyChanged(p->readonly = readOnly);
+        Q_EMIT readOnlyChanged(p->readonly = readOnly);
         setAcceptDrops(!p->readonly);
     }
 }
@@ -776,7 +778,7 @@ void Swatch::setBorder(const QPen& border)
     if ( border != p->border )
     {
         p->border = border;
-        emit borderChanged(border);
+        Q_EMIT borderChanged(border);
         update();
     }
 }


### PR DESCRIPTION
Libraries should not by compiled with Qt keywords as it conflicts
with other libraries during the MOC generation.

This error can be detected during continuous integration by the
Krazy2 tool.

Also fixes a bunch of -Werror related issues with GCC6 and a missing include causing a compilation error in Qt 5.7.

Also fix #19