### PR TITLE
Harmony editors

### DIFF
--- a/include/color_wheel.hpp
+++ b/include/color_wheel.hpp
@@ -143,9 +143,6 @@ public:
      */
     unsigned addOppositeHarmony(unsigned relative_to);
 
-    /// Apply previous added harmonies
-    void applyHarmonies();
-
 public Q_SLOTS:
 
     /// Set current color

--- a/include/color_wheel.hpp
+++ b/include/color_wheel.hpp
@@ -128,6 +128,9 @@ public:
      */
     void addHarmony(double hue_diff, bool editable, int symmetric_to=-1, int opposite_to=-1);
 
+    /// Apply previous added harmonies
+    void applyHarmonies();
+
 public Q_SLOTS:
 
     /// Set current color

--- a/include/color_wheel.hpp
+++ b/include/color_wheel.hpp
@@ -77,6 +77,12 @@ public:
     /// Get current color
     QColor color() const;
 
+    /// Get all harmony colors (including main)
+    QList<QColor> harmonyColors() const;
+
+    /// Get number of harmony colors (including main)
+    unsigned int harmonyCount() const;
+
     virtual QSize sizeHint() const Q_DECL_OVERRIDE;
 
     /// Get current hue in the range [0-1]
@@ -160,6 +166,11 @@ Q_SIGNALS:
     void colorSelected(QColor);
 
     void displayFlagsChanged(ColorWheel::DisplayFlags flags);
+
+    /**
+     * Emitted when harmony settings or harmony colors are changed (including due to main hue change)
+     */
+    void harmonyChanged();
 
 protected:
     void paintEvent(QPaintEvent *) Q_DECL_OVERRIDE;

--- a/include/color_wheel.hpp
+++ b/include/color_wheel.hpp
@@ -4,6 +4,7 @@
  * \author Mattia Basaglia
  *
  * \copyright Copyright (C) 2013-2017 Mattia Basaglia
+ * \copyright Copyright (C) 2017 caryoscelus
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -108,6 +109,18 @@ public:
      * @param mask  Mask to be cleared
      */
     void setDisplayFlag(DisplayFlags flag, DisplayFlags mask);
+
+    /// Clear harmony color scheme
+    void clearHarmonies();
+
+    /**
+     * @brief Add harmony color
+     * @param hue_diff     Initial hue difference (in [0-1) range)
+     * @param editable     Whether this harmony should be editable
+     * @param symmetric_to Index of other harmony that should symmetric relative to main hue (or -1 for none)
+     * @param opposite_to  Index of other harmony that should be opposite to this (or -1)
+     */
+    void addHarmony(double hue_diff, bool editable, int symmetric_to=-1, int opposite_to=-1);
 
 public Q_SLOTS:
 

--- a/include/color_wheel.hpp
+++ b/include/color_wheel.hpp
@@ -123,10 +123,25 @@ public:
      * @brief Add harmony color
      * @param hue_diff     Initial hue difference (in [0-1) range)
      * @param editable     Whether this harmony should be editable
-     * @param symmetric_to Index of other harmony that should symmetric relative to main hue (or -1 for none)
-     * @param opposite_to  Index of other harmony that should be opposite to this (or -1)
+     * @returns Index of newly added harmony
      */
-    void addHarmony(double hue_diff, bool editable, int symmetric_to=-1, int opposite_to=-1);
+    unsigned addHarmony(double hue_diff, bool editable);
+
+    /**
+     * @brief Add symmetric harmony color
+     * @param relative_to  Index of other harmony that should be symmetric relative to main hue
+     * @param editable     Whether this harmony should be editable
+     * @returns Index of newly added harmony
+     */
+    unsigned addSymmetricHarmony(unsigned relative_to, bool editable);
+
+    /**
+     * @brief Add opposite harmony color
+     * @param relative_to  Index of other harmony that should be opposite to this
+     * @param editable     Whether this harmony should be editable
+     * @returns Index of newly added harmony
+     */
+    unsigned addOppositeHarmony(unsigned relative_to, bool editable);
 
     /// Apply previous added harmonies
     void applyHarmonies();

--- a/include/color_wheel.hpp
+++ b/include/color_wheel.hpp
@@ -130,18 +130,18 @@ public:
     /**
      * @brief Add symmetric harmony color
      * @param relative_to  Index of other harmony that should be symmetric relative to main hue
-     * @param editable     Whether this harmony should be editable
      * @returns Index of newly added harmony
+     * Editability is inherited from symmetric editor
      */
-    unsigned addSymmetricHarmony(unsigned relative_to, bool editable);
+    unsigned addSymmetricHarmony(unsigned relative_to);
 
     /**
      * @brief Add opposite harmony color
      * @param relative_to  Index of other harmony that should be opposite to this
-     * @param editable     Whether this harmony should be editable
      * @returns Index of newly added harmony
+     * Editability is inherited from opposite editor
      */
-    unsigned addOppositeHarmony(unsigned relative_to, bool editable);
+    unsigned addOppositeHarmony(unsigned relative_to);
 
     /// Apply previous added harmonies
     void applyHarmonies();

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -297,7 +297,10 @@ QList<QColor> ColorWheel::harmonyColors() const
     QList<QColor> result;
     result.push_back(color());
     for (auto const& harmony : p->ring_components)
-        result.push_back(p->color_from(p->hue+harmony.hue_diff, p->sat, p->val, 1));
+    {
+        auto hue = normalize(p->hue+harmony.hue_diff);
+        result.push_back(p->color_from(hue, p->sat, p->val, 1));
+    }
     return result;
 }
 
@@ -453,7 +456,7 @@ void ColorWheel::mouseMoveEvent(QMouseEvent *ev)
                 auto& opposite = p->ring_components[component.opposite_to];
                 opposite.hue_diff = normalize(component.hue_diff-0.5);
             }
-            // TODO: emit signals
+            Q_EMIT harmonyChanged();
             update();
         }
     }

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -56,13 +56,12 @@ struct RingComponent
     }
 };
 
-double normalize(double angle)
+/**
+ * Puts a double into [0; 1) range
+ */
+inline double normalize(double angle)
 {
-    if (angle < 0)
-        return angle + std::abs(std::floor(angle));
-    if (angle > 1)
-        return angle - std::floor(angle);
-    return angle;
+    return angle - std::floor(angle);
 }
 
 class ColorWheel::Private

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -272,6 +272,17 @@ public:
             val = detail::color_lumaF(c);
         }
     }
+
+    void draw_ring_editor(double editor_hue, QPainter& painter, QColor color) {
+        painter.setPen(QPen(color,3));
+        painter.setBrush(Qt::NoBrush);
+        QLineF ray(0, 0, outer_radius(), 0);
+        ray.setAngle(editor_hue*360);
+        QPointF h1 = ray.p2();
+        ray.setLength(inner_radius());
+        QPointF h2 = ray.p2();
+        painter.drawLine(h1,h2);
+    }
 };
 
 ColorWheel::ColorWheel(QWidget *parent) :
@@ -356,26 +367,14 @@ void ColorWheel::paintEvent(QPaintEvent * )
     painter.drawPixmap(-p->outer_radius(), -p->outer_radius(), p->hue_ring);
 
     // hue selector
-    painter.setPen(QPen(Qt::black,3));
-    painter.setBrush(Qt::NoBrush);
-    QLineF ray(0, 0, p->outer_radius(), 0);
-    ray.setAngle(p->hue*360);
-    QPointF h1 = ray.p2();
-    ray.setLength(p->inner_radius());
-    QPointF h2 = ray.p2();
-    painter.drawLine(h1,h2);
+    p->draw_ring_editor(p->hue, painter, Qt::black);
 
     for (auto const& editor : p->ring_editors)
     {
-        // TODO: separate function
-        painter.setPen(QPen(Qt::white,3));
-        painter.setBrush(Qt::NoBrush);
-        QLineF ray(0, 0, p->outer_radius(), 0);
-        ray.setAngle((p->hue+editor.hue_diff)*360);
-        QPointF h1 = ray.p2();
-        ray.setLength(p->inner_radius());
-        QPointF h2 = ray.p2();
-        painter.drawLine(h1,h2);
+        auto hue = p->hue+editor.hue_diff;
+        // TODO: better color for uneditable indicator
+        auto color = editor.editable ? Qt::white : Qt::gray;
+        p->draw_ring_editor(hue, painter, color);
     }
 
     // lum-sat square

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -48,10 +48,12 @@ struct RingComponent
     double hue_diff;
     bool editable;
     int symmetric_to;
-    RingComponent(double hue_diff_, bool editable_, int symmetric_to_) :
+    int opposite_to;
+    RingComponent(double hue_diff_, bool editable_, int symmetric_to_=-1, int opposite_to_=-1) :
         hue_diff(hue_diff_),
         editable(editable_),
-        symmetric_to(symmetric_to_)
+        symmetric_to(symmetric_to_),
+        opposite_to(opposite_to_)
     {
     }
 };
@@ -277,8 +279,9 @@ ColorWheel::ColorWheel(QWidget *parent) :
 {
     setDisplayFlags(FLAGS_DEFAULT);
     setAcceptDrops(true);
-    p->ring_components.emplace_back(0.5, true, 1);
-    p->ring_components.emplace_back(0.5, true, 0);
+    p->ring_components.emplace_back(0.5, false);
+    p->ring_components.emplace_back(0.125, true, -1, 2);
+    p->ring_components.emplace_back(0.625, true, -1, 1);
 }
 
 ColorWheel::~ColorWheel()
@@ -432,6 +435,11 @@ void ColorWheel::mouseMoveEvent(QMouseEvent *ev)
             {
                 auto& symmetric = p->ring_components[component.symmetric_to];
                 symmetric.hue_diff = normalize(p->hue - hue);
+            }
+            else if (component.opposite_to != -1)
+            {
+                auto& opposite = p->ring_components[component.opposite_to];
+                opposite.hue_diff = normalize(component.hue_diff-0.5);
             }
             // TODO: emit signals
             update();

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -279,9 +279,6 @@ ColorWheel::ColorWheel(QWidget *parent) :
 {
     setDisplayFlags(FLAGS_DEFAULT);
     setAcceptDrops(true);
-    p->ring_components.emplace_back(0.5, false);
-    p->ring_components.emplace_back(0.125, true, -1, 2);
-    p->ring_components.emplace_back(0.625, true, -1, 1);
 }
 
 ColorWheel::~ColorWheel()
@@ -650,6 +647,29 @@ void ColorWheel::dropEvent(QDropEvent* event)
             event->accept();
         }
     }
+}
+
+void ColorWheel::clearHarmonies()
+{
+    p->ring_components.clear();
+    p->current_ring_component = -1;
+    update();
+}
+
+void ColorWheel::addHarmony(double hue_diff, bool editable, int symmetric_to, int opposite_to)
+{
+    hue_diff = normalize(hue_diff);
+    if (symmetric_to >= 0 && opposite_to >= 0)
+        throw std::runtime_error("incorrect call to addHarmony: harmony cannot be both symmetric and opposite");
+    int harmony_count = p->ring_components.size();
+    if (symmetric_to >= harmony_count || opposite_to >= harmony_count)
+        throw std::runtime_error("incorrect call to addHarmony: harmony number out of range");
+    p->ring_components.emplace_back(hue_diff, editable, symmetric_to, opposite_to);
+    if (symmetric_to >= 0)
+        p->ring_components[symmetric_to].symmetric_to = harmony_count;
+    else if (opposite_to >= 0)
+        p->ring_components[opposite_to].opposite_to = harmony_count;
+    update();
 }
 
 } //  namespace color_widgets

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -283,6 +283,12 @@ public:
         QPointF h2 = ray.p2();
         painter.drawLine(h1,h2);
     }
+
+    /// Apply harmony changes
+    void apply_harmonies() {
+        Q_EMIT w->harmonyChanged();
+        w->update();
+    }
 };
 
 ColorWheel::ColorWheel(QWidget *parent) :
@@ -455,8 +461,7 @@ void ColorWheel::mouseMoveEvent(QMouseEvent *ev)
                 auto& opposite = p->ring_editors[editor.opposite_to];
                 opposite.hue_diff = normalize(editor.hue_diff-0.5);
             }
-            Q_EMIT harmonyChanged();
-            update();
+            p->apply_harmonies();
         }
     }
     else if(p->mouse_status == DragSquare)
@@ -670,14 +675,14 @@ void ColorWheel::clearHarmonies()
 {
     p->ring_editors.clear();
     p->current_ring_editor = -1;
-    Q_EMIT harmonyChanged();
-    update();
+    p->apply_harmonies();
 }
 
 unsigned ColorWheel::addHarmony(double hue_diff, bool editable)
 {
     auto count = p->ring_editors.size();
     p->ring_editors.emplace_back(normalize(hue_diff), editable, -1, -1);
+    p->apply_harmonies();
     return count;
 }
 
@@ -689,6 +694,7 @@ unsigned ColorWheel::addSymmetricHarmony(unsigned relative_to)
     auto& relative = p->ring_editors[relative_to];
     relative.symmetric_to = count;
     p->ring_editors.emplace_back(normalize(-relative.hue_diff), relative.editable, relative_to, -1);
+    p->apply_harmonies();
     return count;
 }
 
@@ -700,13 +706,8 @@ unsigned ColorWheel::addOppositeHarmony(unsigned relative_to)
     auto& relative = p->ring_editors[relative_to];
     relative.opposite_to = count;
     p->ring_editors.emplace_back(normalize(0.5+relative.hue_diff), relative.editable, -1, relative_to);
+    p->apply_harmonies();
     return count;
-}
-
-void ColorWheel::applyHarmonies()
-{
-    Q_EMIT harmonyChanged();
-    update();
 }
 
 } //  namespace color_widgets

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -688,7 +688,7 @@ unsigned ColorWheel::addSymmetricHarmony(unsigned relative_to)
         throw std::out_of_range("incorrect call to addSymmetricHarmony: harmony number out of range");
     auto& relative = p->ring_editors[relative_to];
     relative.symmetric_to = count;
-    p->ring_editors.emplace_back(-relative.hue_diff, relative.editable, relative_to, -1);
+    p->ring_editors.emplace_back(normalize(-relative.hue_diff), relative.editable, relative_to, -1);
     return count;
 }
 
@@ -699,7 +699,7 @@ unsigned ColorWheel::addOppositeHarmony(unsigned relative_to)
         throw std::out_of_range("incorrect call to addOppositeHarmony: harmony number out of range");
     auto& relative = p->ring_editors[relative_to];
     relative.opposite_to = count;
-    p->ring_editors.emplace_back(0.5+relative.hue_diff, relative.editable, -1, relative_to);
+    p->ring_editors.emplace_back(normalize(0.5+relative.hue_diff), relative.editable, -1, relative_to);
     return count;
 }
 

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -279,6 +279,7 @@ ColorWheel::ColorWheel(QWidget *parent) :
 {
     setDisplayFlags(FLAGS_DEFAULT);
     setAcceptDrops(true);
+    connect(this, SIGNAL(colorChanged(QColor)), this, SIGNAL(harmonyChanged()));
 }
 
 ColorWheel::~ColorWheel()
@@ -289,6 +290,20 @@ ColorWheel::~ColorWheel()
 QColor ColorWheel::color() const
 {
     return p->color_from(p->hue, p->sat, p->val, 1);
+}
+
+QList<QColor> ColorWheel::harmonyColors() const
+{
+    QList<QColor> result;
+    result.push_back(color());
+    for (auto const& harmony : p->ring_components)
+        result.push_back(p->color_from(p->hue+harmony.hue_diff, p->sat, p->val, 1));
+    return result;
+}
+
+unsigned int ColorWheel::harmonyCount() const
+{
+    return 1 + p->ring_components.size();
 }
 
 QSize ColorWheel::sizeHint() const
@@ -653,6 +668,7 @@ void ColorWheel::clearHarmonies()
 {
     p->ring_components.clear();
     p->current_ring_component = -1;
+    Q_EMIT harmonyChanged();
     update();
 }
 
@@ -669,6 +685,7 @@ void ColorWheel::addHarmony(double hue_diff, bool editable, int symmetric_to, in
         p->ring_components[symmetric_to].symmetric_to = harmony_count;
     else if (opposite_to >= 0)
         p->ring_components[opposite_to].opposite_to = harmony_count;
+    Q_EMIT harmonyChanged();
     update();
 }
 

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -681,25 +681,25 @@ unsigned ColorWheel::addHarmony(double hue_diff, bool editable)
     return count;
 }
 
-unsigned ColorWheel::addSymmetricHarmony(unsigned relative_to, bool editable)
+unsigned ColorWheel::addSymmetricHarmony(unsigned relative_to)
 {
     auto count = p->ring_editors.size();
     if (relative_to >= count)
         throw std::out_of_range("incorrect call to addSymmetricHarmony: harmony number out of range");
-    p->ring_editors[relative_to].symmetric_to = count;
-    auto hue_diff = -p->ring_editors[relative_to].hue_diff;
-    p->ring_editors.emplace_back(hue_diff, editable, relative_to, -1);
+    auto& relative = p->ring_editors[relative_to];
+    relative.symmetric_to = count;
+    p->ring_editors.emplace_back(-relative.hue_diff, relative.editable, relative_to, -1);
     return count;
 }
 
-unsigned ColorWheel::addOppositeHarmony(unsigned relative_to, bool editable)
+unsigned ColorWheel::addOppositeHarmony(unsigned relative_to)
 {
     auto count = p->ring_editors.size();
     if (relative_to >= count)
         throw std::out_of_range("incorrect call to addOppositeHarmony: harmony number out of range");
-    p->ring_editors[relative_to].opposite_to = count;
-    auto hue_diff = 0.5+p->ring_editors[relative_to].hue_diff;
-    p->ring_editors.emplace_back(hue_diff, editable, -1, relative_to);
+    auto& relative = p->ring_editors[relative_to];
+    relative.opposite_to = count;
+    p->ring_editors.emplace_back(0.5+relative.hue_diff, relative.editable, -1, relative_to);
     return count;
 }
 

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -688,6 +688,10 @@ void ColorWheel::addHarmony(double hue_diff, bool editable, int symmetric_to, in
         p->ring_components[symmetric_to].symmetric_to = harmony_count;
     else if (opposite_to >= 0)
         p->ring_components[opposite_to].opposite_to = harmony_count;
+}
+
+void ColorWheel::applyHarmonies()
+{
     Q_EMIT harmonyChanged();
     update();
 }

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -49,11 +49,11 @@ struct RingEditor
     bool editable;
     int symmetric_to;
     int opposite_to;
-    RingEditor(double hue_diff_, bool editable_, int symmetric_to_=-1, int opposite_to_=-1) :
-        hue_diff(hue_diff_),
-        editable(editable_),
-        symmetric_to(symmetric_to_),
-        opposite_to(opposite_to_)
+    RingEditor(double hue_diff, bool editable, int symmetric_to=-1, int opposite_to=-1) :
+        hue_diff(hue_diff),
+        editable(editable),
+        symmetric_to(symmetric_to),
+        opposite_to(opposite_to)
     {
     }
 };

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -43,7 +43,8 @@ static const ColorWheel::DisplayFlags hard_default_flags = ColorWheel::SHAPE_TRI
 static ColorWheel::DisplayFlags default_flags = hard_default_flags;
 static const double selector_radius = 6;
 
-struct RingComponent {
+struct RingComponent
+{
     double hue_diff;
     bool editable;
     RingComponent(double hue_diff_, bool editable_) :
@@ -52,6 +53,15 @@ struct RingComponent {
     {
     }
 };
+
+double normalize(double angle)
+{
+    if (angle < 0)
+        return angle + std::abs(std::floor(angle));
+    if (angle > 1)
+        return angle - std::floor(angle);
+    return angle;
+}
 
 class ColorWheel::Private
 {
@@ -266,7 +276,7 @@ ColorWheel::ColorWheel(QWidget *parent) :
 {
     setDisplayFlags(FLAGS_DEFAULT);
     setAcceptDrops(true);
-    p->ring_components.emplace_back(0.5, false);
+    p->ring_components.emplace_back(0.5, true);
 }
 
 ColorWheel::~ColorWheel()
@@ -415,7 +425,7 @@ void ColorWheel::mouseMoveEvent(QMouseEvent *ev)
         else
         {
             auto& component = p->ring_components[p->current_ring_component];
-            component.hue_diff = p->hue - hue;
+            component.hue_diff = normalize(hue - p->hue);
             // TODO: emit signals
             update();
         }
@@ -466,7 +476,7 @@ void ColorWheel::mousePressEvent(QMouseEvent *ev)
         else if ( ray.length() <= p->outer_radius() )
         {
             p->mouse_status = DragCircle;
-            auto hue_diff = p->hue - ray.angle()/360;
+            auto hue_diff = normalize(ray.angle()/360 - p->hue);
             auto i = 0;
             for (auto const& component : p->ring_components)
             {

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -488,9 +488,10 @@ void ColorWheel::mousePressEvent(QMouseEvent *ev)
             auto i = 0;
             for (auto const& component : p->ring_components)
             {
+                const double eps = 1.0/64;
                 if (component.editable &&
-                    component.hue_diff <= hue_diff + 0.0625 &&
-                    component.hue_diff >= hue_diff - 0.0625)
+                    component.hue_diff <= hue_diff + eps &&
+                    component.hue_diff >= hue_diff - eps)
                 {
                     p->current_ring_component = i;
                     // no need to update color..

--- a/src/color_wheel.cpp
+++ b/src/color_wheel.cpp
@@ -47,9 +47,11 @@ struct RingComponent
 {
     double hue_diff;
     bool editable;
-    RingComponent(double hue_diff_, bool editable_) :
+    int symmetric_to;
+    RingComponent(double hue_diff_, bool editable_, int symmetric_to_) :
         hue_diff(hue_diff_),
-        editable(editable_)
+        editable(editable_),
+        symmetric_to(symmetric_to_)
     {
     }
 };
@@ -276,7 +278,8 @@ ColorWheel::ColorWheel(QWidget *parent) :
 {
     setDisplayFlags(FLAGS_DEFAULT);
     setAcceptDrops(true);
-    p->ring_components.emplace_back(0.5, true);
+    p->ring_components.emplace_back(0.5, true, 1);
+    p->ring_components.emplace_back(0.5, true, 0);
 }
 
 ColorWheel::~ColorWheel()
@@ -426,6 +429,11 @@ void ColorWheel::mouseMoveEvent(QMouseEvent *ev)
         {
             auto& component = p->ring_components[p->current_ring_component];
             component.hue_diff = normalize(hue - p->hue);
+            if (component.symmetric_to != -1)
+            {
+                auto& symmetric = p->ring_components[component.symmetric_to];
+                symmetric.hue_diff = normalize(p->hue - hue);
+            }
             // TODO: emit signals
             update();
         }


### PR DESCRIPTION
Hello,

First of all, thanks for your awesome library! I'm working on an advanced color selector widget (to be used in [OpenToonz](https://github.com/opentoonz/opentoonz) and [RainyNite](https://notabug.org/caryoscelus/rainynite-studio)). The first feature i want to implement in it is "harmony editors", allowing user to select few colors connected by harmony (see e.g. http://www.tigercolor.com/color-lab/color-theory/color-theory-intro.htm#color_harmonies). So here it is, as an optional API for ColorWheel widget.

Here's a demo app that makes use of harmony editor: https://notabug.org/caryoscelus/color-widgets-demos

Screenshot: 
![color_selector_2](https://user-images.githubusercontent.com/1758893/28168238-1b0b810c-67e7-11e7-8d56-47535a8405cb.png)
