### PR TITLE
Improvements to CMake and fixed readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ moc_*.cpp
 Makefile
 out/*
 build/
+
+cmake-build-*/
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,10 @@ install_project (
 
 add_subdirectory (gallery)
 
-find_package (Qt5Designer)
-if (Qt5Designer_FOUND)
-    add_subdirectory (color_widgets_designer_plugin)
-endif(Qt5Designer_FOUND)
+option(QTCOLORWIDGETS_DESIGNER_PLUGIN "Build QtDesigner plugin" ON)
+if (${QTCOLORWIDGETS_DESIGNER_PLUGIN})
+    find_package (Qt5Designer)
+    if (Qt5Designer_FOUND)
+        add_subdirectory (color_widgets_designer_plugin)
+    endif(Qt5Designer_FOUND)
+endif()

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Using it in a project
 
 For QMake-based projects, include color_widgets.pri in the QMake project file.
 For CMake-based projects, add this as subdirectory, it will be compiled as a
-library and you can link the required targets to ColorWidgets-qt5.
+library and you can link the required targets to ColorWidgets.
 All the required files are in ./src and ./include.
 
 


### PR DESCRIPTION
This is as discussed in our email from a few months ago.
The readme named the wrong CMake target. Fixed this.
The QtDesigner plugin is made optional with the `QTCOLORWIDGETS_DESIGNER_PLUGIN` variable, which is set by default to `ON`.